### PR TITLE
Fix a small typo in popup error message

### DIFF
--- a/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
+++ b/plugins/org.jkiss.dbeaver.ext.postgresql/src/org/jkiss/dbeaver/ext/postgresql/model/PostgreDataSource.java
@@ -441,7 +441,7 @@ public class PostgreDataSource extends JDBCDataSource implements DBSObjectSelect
             final List<PostgreDatabase> allDatabases = databaseCache.getCachedObjects();
             if (allDatabases.isEmpty()) {
                 // Looks like we are not connected or in connection process right now - no instance then
-                throw new IllegalStateException("No databases fond on the server");
+                throw new IllegalStateException("No databases found on the server");
             }
             defDatabase = allDatabases.get(0);
         }


### PR DESCRIPTION
"No databases fond on the server" -> "No databases found on the server"